### PR TITLE
Initializing data descriptors from json configuration using runtime init

### DIFF
--- a/Framework/Core/src/WorkflowSerializationHelpers.cxx
+++ b/Framework/Core/src/WorkflowSerializationHelpers.cxx
@@ -387,23 +387,15 @@ struct WorkflowImporter : public rapidjson::BaseReaderHandler<rapidjson::UTF8<>,
     } else if (in(State::IN_INPUT_BINDING)) {
       binding = s;
     } else if (in(State::IN_INPUT_ORIGIN)) {
-      char buf[4] = { 0, 0, 0, 0 };
-      memcpy(buf, s.c_str(), std::min(s.size(), 4UL));
-      origin = header::DataOrigin{ buf };
+      origin.runtimeInit(s.c_str(), std::min(s.size(), 16UL));
     } else if (in(State::IN_INPUT_DESCRIPTION)) {
-      char buf[16] = { 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0 };
-      memcpy(buf, s.c_str(), std::min(s.size(), 16UL));
-      description = header::DataDescription{ buf };
+      description.runtimeInit(s.c_str(), std::min(s.size(), 16UL));
     } else if (in(State::IN_OUTPUT_BINDING)) {
       binding = s;
     } else if (in(State::IN_OUTPUT_ORIGIN)) {
-      char buf[4] = { 0, 0, 0, 0 };
-      memcpy(buf, s.c_str(), std::min(s.size(), 4UL));
-      origin = header::DataOrigin{ buf };
+      origin.runtimeInit(s.c_str(), std::min(s.size(), 16UL));
     } else if (in(State::IN_OUTPUT_DESCRIPTION)) {
-      char buf[16] = { 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0 };
-      memcpy(buf, s.c_str(), std::min(s.size(), 16UL));
-      description = header::DataDescription{ buf };
+      description.runtimeInit(s.c_str(), std::min(s.size(), 16UL));
     } else if (in(State::IN_OPTION_NAME)) {
       optionName = s;
     } else if (in(State::IN_OPTION_TYPE)) {


### PR DESCRIPTION
Using the constexpr init constructor with the temporary variable does not work, still isolating the problem to avoid this in the future. For the particular case here, the `runtimeInit` method is the better solution.